### PR TITLE
fix: Move Podium processing to a preHandler hook

### DIFF
--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -8,15 +8,18 @@ const fp = require('fastify-plugin');
 
 const podiumLayoutFastifyPlugin = (fastify, layout, done) => {
     // Decorate reply with .app.podium we can write to throught the request
-    fastify.decorateReply('app', {
-        podium: {},
+    fastify.decorateReply('app', null);
+    fastify.addHook('onRequest', async (request, reply) => {
+        reply.app = {
+            podium: {},
+        }
     });
 
     // Run parsers on request and store state object on reply.app.podium
-    fastify.addHook('onRequest', async (request, reply) => {
+    fastify.addHook('preHandler', async (request, reply) => {
         const incoming = new utils.HttpIncoming(
-            request.req,
-            reply.res,
+            request.raw,
+            reply.raw,
             reply.app.params,
         );
         reply.app.podium = await layout.process(incoming, { proxy: false });

--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -12,7 +12,7 @@ const podiumLayoutFastifyPlugin = (fastify, layout, done) => {
     fastify.addHook('onRequest', async (request, reply) => {
         reply.app = {
             podium: {},
-        }
+        };
     });
 
     // Run parsers on request and store state object on reply.app.podium

--- a/test/layout-plugin.js
+++ b/test/layout-plugin.js
@@ -17,9 +17,7 @@ class Server {
             ...options,
         });
 
-        layout.view((incoming, fragment) => {
-            return `## ${fragment} ##`;
-        });
+        layout.view((incoming, fragment) => `## ${fragment} ##`);
 
         const podlet = layout.client.register(podletAddr.options);
 


### PR DESCRIPTION
This moves the Podium processing, which includes processing the context, to a pre handler hook instead of running it on the on request hook. 

The reason for this move is that if one extend the context with additional which rely on other hooks, running the context parsers on the on request hook is too early. In other words, the podium processing of the context parsers is run before the custom parsers is done.