### PR TITLE
fix: use additional args when rendering via podiumSend

### DIFF
--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -26,9 +26,9 @@ const podiumLayoutFastifyPlugin = (fastify, layout, done) => {
     });
 
     // Decorate response with .podiumSend() method
-    fastify.decorateReply('podiumSend', function podiumSend(payload) {
+    fastify.decorateReply('podiumSend', function podiumSend(payload, ...args) {
         this.type('text/html; charset=utf-8'); // "this" here is the fastify 'Reply' object
-        this.send(layout.render(this.app.podium, payload));
+        this.send(layout.render(this.app.podium, payload, ...args));
     });
 
     // Mount proxy route as an instance so its executed only on


### PR DESCRIPTION
This plugin currently ignores additional args when rendering the template via `podiumSend`. This aligns the behavior to the [Express middleware implementation](https://github.com/podium-lib/layout/blob/master/lib/layout.js#L283).