### PR TITLE
fix: avoid error when posting json with no body

### DIFF
--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -60,6 +60,13 @@ const podiumLayoutFastifyPlugin = (fastify, layout, done) => {
         next();
     });
 
+    // Users coming from Express will reach an error when posting
+    // an empty body using Content-Type set to application/json
+    // https://stackoverflow.com/a/69458134
+    fastify.addContentTypeParser('application/json', (req, payload, cb) => {
+        cb(null, null);
+    });
+
     done();
 };
 


### PR DESCRIPTION
**What's the problem?**

Some users have reported issues when transitioning from Express to Fastify in regards to how HTTP requests are handled. By default, Fastify will throw an error if a POST request is sent with no body and the Content-Type set to `application/json`.

```sh
"res": { "statusCode":400 }, "err":{ "type":"FastifyError", "message":"Body cannot be empty when content-type is set to 'application/json'" ...
````

In Express this is not the case.

**Proposed solution**

To solve this, this PR adds a custom content type parser for all application/json requests to override the default behavior in Fastify, resulting in a behavior one would expect coming from Express.

**Questions and concerns**

When transitioning from one library to another one should expect "regressions" like these, as different libraries have different opinions on how to handle these kinds of things. I attempted to find details about a request body being required in the HTTP spec when Content-Type is set to application/json but couldn't find anything, hence why a solution like this seems applicable.

However, I still don't know if adding a content parser to the layout middleware is the right way to go about this or if we should stick to Fastify's default behavior as much as possible and tell people to add this themselves or add a body to their request. I'm keen to hear your thoughts on this.