### PR TITLE
fix: use LTS aliases to not chase node version anymore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [lts/-1, lts]
+        node-version: [lts/-1, lts/*]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [lts/-1, lts]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Renovate is blocked on bumping to Fastify 4 because the Node versions haven't seen love in a while.

This changes to the supported LTS aliases to just grab the active-LTS and maintenance-LTS.