### PR TITLE
Enabling tests to run on Node v18 and newer

### DIFF
--- a/test/layout-plugin.js
+++ b/test/layout-plugin.js
@@ -32,7 +32,7 @@ class Server {
     listen() {
         return new Promise((resolve, reject) => {
             this.app
-                .listen(0)
+                .listen({ port: 0, host: '127.0.0.1' })
                 .then(() => {
                     const address = this.app.server.address();
                     const url = `http://${address.address}:${address.port}`;


### PR DESCRIPTION
When running these tests with Node version 18 and newer the `test-utils/request.js` library throws an error when being handed the default hostname set på Fastify `::1`.

Being explicit about which host to bind with works around this problem. A follow up task could be to address the underlying issue in the test utils module.