### PR TITLE
fix - removing Fastify version range configuration

### DIFF
--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -64,6 +64,5 @@ const podiumLayoutFastifyPlugin = (fastify, layout, done) => {
 };
 
 module.exports = fp(podiumLayoutFastifyPlugin, {
-    fastify: '2.x || 3.x',
     name: 'podium-layout',
 });


### PR DESCRIPTION
We no longer enforce certain versions of Fastify for this plugin and thereby enabling anyone to use it with Fastify v4 and newer.