### PR TITLE
fix: bumping version to get version range into a version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ please see the [Podium documentation].
 $ npm install @podium/fastify-layout
 ```
 
-## Requirements
-
-This module require Fastify v2.0.0 or newer.
-
 ## Simple usage
 
 Build a simple layout server including a single podlet:


### PR DESCRIPTION
Making a new release in order to get a version containing the version range fix: 9edd12bb5b2d0c62228a1552878dbe01af4315af