### PR TITLE
fix: avoid destructively setting reply.app.podium

### DIFF
--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -8,8 +8,12 @@ const podiumLayoutFastifyPlugin = (fastify, layout, done) => {
     // Decorate reply with .app.podium we can write to throughout the request
     fastify.decorateReply('app', null);
     fastify.addHook('onRequest', async (request, reply) => {
+        // namespace
         reply.app = reply.app || {};
+        // used to hold the HttpIncoming object
         reply.app.podium = reply.app.podium || {};
+        // used to pass additional values to HttpIncoming
+        reply.app.params = reply.app.params || {};
     });
 
     // Run parsers on request and store state object on reply.app.podium

--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -5,12 +5,11 @@ import { HttpIncoming, pathnameBuilder } from '@podium/utils';
 import fp from 'fastify-plugin';
 
 const podiumLayoutFastifyPlugin = (fastify, layout, done) => {
-    // Decorate reply with .app.podium we can write to throught the request
+    // Decorate reply with .app.podium we can write to throughout the request
     fastify.decorateReply('app', null);
     fastify.addHook('onRequest', async (request, reply) => {
-        reply.app = {
-            podium: {},
-        };
+        reply.app = reply.app || {};
+        reply.app.podium = reply.app.podium || {};
     });
 
     // Run parsers on request and store state object on reply.app.podium


### PR DESCRIPTION
This caused me no end of grief when trying to get brand, host and locale plugins and context parsers to work with Fastify.
Essentially, a plugin (eg. brand) needs to run BEFORE the layout plugin and set a value that a context parser can pick up. This value MUST be set on reply.app.params in order for the value to be available to the context parser but after the brand plugin ran, this plugin would run and wipe reply.app.params.

This PR changes things to just non destructively initialise reply.app, reply.app.params and reply.app.podium.