### PR TITLE
fix: run podium processes earlier in Fastify lifecycle

### DIFF
--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -10,20 +10,17 @@ const podiumLayoutFastifyPlugin = (fastify, layout, done) => {
     fastify.addHook('onRequest', async (request, reply) => {
         // namespace
         reply.app = reply.app || {};
-        // used to hold the HttpIncoming object
-        reply.app.podium = reply.app.podium || {};
         // used to pass additional values to HttpIncoming
         reply.app.params = reply.app.params || {};
-    });
-
-    // Run parsers on request and store state object on reply.app.podium
-    fastify.addHook('preHandler', async (request, reply) => {
-        const incoming = new HttpIncoming(
+        // used to hold the HttpIncoming object
+        reply.app.podium = new HttpIncoming(
             request.raw,
             reply.raw,
             reply.app.params,
         );
-        reply.app.podium = await layout.process(incoming, { proxy: false });
+        reply.app.podium = await layout.process(reply.app.podium, {
+            proxy: false,
+        });
     });
 
     // Decorate response with .podiumSend() method


### PR DESCRIPTION
## Why?
When an error occurs in the Fastify lifecycle, subsequent hooks won't be run and so if an error occurs quite early, the preHandler is not run. This means that pretty much any time an error occurs and the error handler kicks in, reply.app.podium will be an empty object and Podium won't have had a chance to run parsers etc. I suspect this is not what we want and that we would be better off running Podium stuff as early as possible. This PR does this by moving Podium setup into an earlier onRequest hook.

Thoughts @trygve-lie ?