### PR TITLE
fix: return the FastifyReply so async works as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ app.register(FastifyLayout, layout);
 app.get(layout.pathname(), async (request, reply) => {
     const incoming = reply.app.podium;
     const result = await podlet.fetch(incoming);
-    reply.podiumSend(result.content);
-    await reply;
+    return reply.podiumSend(result.content);
 });
 
 const start = async () => {

--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -39,8 +39,15 @@ export default fp(
              */
             function podiumSend(payload, ...args) {
                 this.type('text/html; charset=utf-8'); // "this" here is the fastify 'Reply' object
-                // @ts-ignore We type this for our consumers with fixup.sh
-                this.send(layout.render(this.app.podium, payload, ...args));
+                return this.send(
+                    layout.render(
+                        // @ts-ignore We type this for our consumers with fixup.sh
+                        this.app.podium,
+                        // @ts-ignore
+                        payload,
+                        ...args,
+                    ),
+                );
             },
         );
 

--- a/tests/layout-plugin.test.js
+++ b/tests/layout-plugin.test.js
@@ -22,7 +22,7 @@ class Server {
 
         this.app.get(layout.pathname(), async (req, reply) => {
             const result = await podlet.fetch(reply.app.podium);
-            reply.podiumSend(result);
+            return reply.podiumSend(result);
         });
     }
 

--- a/types/podium.d.ts
+++ b/types/podium.d.ts
@@ -33,10 +33,9 @@ declare module 'fastify' {
          *
          * @param markup The HTML contents of the document
          * @param args Parameters sent to the template function
-         * @returns {void} Sends the FastifyReply
          *
          * @see https://podium-lib.io/docs/api/layout#respodiumsendfragment
          */
-        podiumSend: (markup: unknown, ...args: unknown[]) => void;
+        podiumSend(markup: unknown, ...args: unknown[]): FastifyReply;
     }
 }


### PR DESCRIPTION
Fit the `return reply.send` pattern of async/await in Fastify

https://fastify.dev/docs/latest/Reference/Routes/#async-await