### PR TITLE
fix: process incoming request and params later

### DIFF
--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -7,24 +7,36 @@ export default fp(
      */
     (fastify, layout, done) => {
         // Decorate reply with .app.podium we can write to throughout the request
-        fastify.decorateReply('app', null);
+        if (!fastify.hasReplyDecorator('app')) {
+            fastify.decorateReply('app', null);
+        }
+
         fastify.addHook('onRequest', async (request, reply) => {
-            // namespace
+            // @ts-ignore We decorate this above
+            reply.app = reply.app || {};
+
             // @ts-ignore We type this for our consumers with fixup.sh
             reply.app = reply.app || {};
+
             // used to pass additional values to HttpIncoming
             // @ts-ignore We type this for our consumers with fixup.sh
             reply.app.params = reply.app.params || {};
-            // used to hold the HttpIncoming object
-            // @ts-ignore We type this for our consumers with fixup.sh
-            reply.app.podium = new HttpIncoming(
+        });
+
+        // Run as late as we can (but before the route handler) so other plugins
+        // can add to `reply.app.params` using either of the hooks in
+        // the lifecycle before it https://fastify.dev/docs/latest/Reference/Hooks/#hooks
+        fastify.addHook('preHandler', async (request, reply) => {
+            const incoming = new HttpIncoming(
                 request.raw,
                 reply.raw,
                 // @ts-ignore We type this for our consumers with fixup.sh
                 reply.app.params,
             );
+
+            // used to hold the HttpIncoming object
             // @ts-ignore We type this for our consumers with fixup.sh
-            reply.app.podium = await layout.process(reply.app.podium, {
+            reply.app.podium = await layout.process(incoming, {
                 proxy: false,
             });
         });


### PR DESCRIPTION
We had a plugin registered in `preHandler` that placed things on `reply.app.params`, but these weren't picked up since our handler here ran before it.