### PR TITLE
fix: include the protocol when creating HttpIncoming

### DIFF
--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -28,7 +28,10 @@ export default fp(
         // the lifecycle before it https://fastify.dev/docs/latest/Reference/Hooks/#hooks
         fastify.addHook('preHandler', async (request, reply) => {
             // @ts-expect-error We need the protocol in HttpIncoming https://github.com/podium-lib/utils/blob/1b636c2c8da25e59064e6051a4ae2de1d5e5b7b3/lib/http-incoming.js#L6-L11 but it's not on the raw request by default
-            request.raw.protocol = request.protocol;
+            if (!request.raw.protocol) {
+                // @ts-expect-error
+                request.raw.protocol = request.protocol;
+            }
             const incoming = new HttpIncoming(
                 request.raw,
                 reply.raw,

--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -27,6 +27,8 @@ export default fp(
         // can add to `reply.app.params` using either of the hooks in
         // the lifecycle before it https://fastify.dev/docs/latest/Reference/Hooks/#hooks
         fastify.addHook('preHandler', async (request, reply) => {
+            // @ts-expect-error We need the protocol in HttpIncoming https://github.com/podium-lib/utils/blob/1b636c2c8da25e59064e6051a4ae2de1d5e5b7b3/lib/http-incoming.js#L6-L11 but it's not on the raw request by default
+            request.raw.protocol = request.protocol;
             const incoming = new HttpIncoming(
                 request.raw,
                 reply.raw,


### PR DESCRIPTION
Noticed that podlets using mount origin from the context didn't get the correct protocol in in HTTPS origins.

https://github.com/podium-lib/context/blob/main/lib/get-mount-origin.js

Turns out the raw request we pass down in the Fastify plugin doesn't include the protocol.