### PR TITLE
fix: handle JSON bodies for proxied POST, PUT, DELETE APIs

### DIFF
--- a/lib/layout-plugin.js
+++ b/lib/layout-plugin.js
@@ -68,15 +68,22 @@ export default fp(
             },
         );
 
-        // Mount proxy route as an instance so its executed only on
-        // the registered path. Iow: the proxy check is not run on
-        // any other routes
+        // Mount proxy route as a plugin so its executed only on
+        // the registered path and changes we do to the Fastify
+        // instance only applies to proxy routes.
+        // In other words, the proxy check is not run on any other routes.
         fastify.register((instance, opts, next) => {
             const pathname = pathnameBuilder(
                 layout.httpProxy.pathname,
                 layout.httpProxy.prefix,
                 '/*',
             );
+
+            // Remove the built-in application/json parser in Fastify from
+            // the proxy routes instance, otherwise the request stream is
+            // already consumed at this point when we try to proxy it,
+            // leading to failing requests (timeouts).
+            instance.removeAllContentTypeParsers();
 
             // Allow all content types for proxy requests
             // https://github.com/fastify/fastify/blob/master/docs/ContentTypeParser.md#catch-all


### PR DESCRIPTION
Fixes an issue where proxied[1] APIs that took JSON content on POST, PUT or DELETE would fail with a timeout.

The cause was a combination of when the Podium plugin runs in Fastify's lifecycle[2], that Fastify ships a built-in content parser for JSON[3], and that our proxy depended on the request ReadableStream emitting data in order to work.

Our proxy would end up coming in too late, after the request stream had been consumed.

The fix is to remove the content type parser for proxied routes, since we in any case aren't interested in the request contents at the layout level.

[1]: https://podium-lib.io/docs/guides/proxying
[2]: https://fastify.dev/docs/latest/Reference/Lifecycle/
[3]: https://fastify.dev/docs/latest/Reference/ContentTypeParser/