### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:podium-lib/fastify-layout.git"
+    "url": "git+https://github.com/podium-lib/fastify-layout.git"
   },
   "bugs": {
     "url": "https://github.com/podium-lib/issues"


### PR DESCRIPTION
## Summary

- Update the npm package repository metadata to use the public HTTPS GitHub URL.
- Keep the repository target unchanged while avoiding an SSH-only URL that requires GitHub key access.

## Validation

- `node` metadata assertion for `package.json`
- `git diff --check`
- `git ls-remote https://github.com/podium-lib/fastify-layout.git HEAD`
- `npm ci --ignore-scripts`
- `npm run lint`
- `npm run types`
- `npm test`
- `npm pack --dry-run`
